### PR TITLE
Refactor SDK state into DeviceStateStore

### DIFF
--- a/src/DeviceStateStore.js
+++ b/src/DeviceStateStore.js
@@ -1,0 +1,144 @@
+export default class DeviceStateStore {
+  constructor(instanceId) {
+    this.userId = null;
+    this._instanceId = instanceId;
+    this._dbConn = null;
+  }
+
+  get _dbName() {
+    return `beams-${this._instanceId}`;
+  }
+
+  connect() {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open(this._dbName);
+
+      request.onerror = event => {
+        const error = new Error(`Database error: ${event.target.error}`);
+        reject(error);
+      };
+
+      request.onsuccess = event => {
+        const db = event.target.result;
+        this._dbConn = db;
+        this._readState()
+          .then(state => {
+            if (state === null) {
+              this.clear();
+            } else {
+              return Promise.resolve();
+            }
+          })
+          .then(resolve);
+      };
+
+      request.onupgradeneeded = event => {
+        const db = event.target.result;
+        db.createObjectStore('beams', {
+          keyPath: 'instance_id',
+        });
+      };
+    });
+  }
+
+  get isConnected() {
+    return this._dbConn !== null;
+  }
+
+  clear() {
+    return this._writeState({
+      instance_id: this._instanceId,
+      device_id: null,
+      token: null,
+      user_id: null,
+    });
+  }
+
+  _readState() {
+    if (!this.isConnected) {
+      throw new Error(
+        'Cannot read value: DeviceStateStore not connected to IndexedDB'
+      );
+    }
+
+    return new Promise((resolve, reject) => {
+      const request = this._dbConn
+        .transaction('beams')
+        .objectStore('beams')
+        .get(this._instanceId);
+
+      request.onsuccess = event => {
+        const state = event.target.result;
+        if (!state) {
+          resolve(null);
+        }
+        resolve(state);
+      };
+
+      request.onerror = event => {
+        reject(event.target.error);
+      };
+    });
+  }
+
+  async _readProperty(name) {
+    const state = await this._readState();
+    if (state === null) {
+      return null;
+    }
+    return state[name] || null;
+  }
+
+  _writeState(state) {
+    if (!this.isConnected) {
+      throw new Error(
+        'Cannot write value: DeviceStateStore not connected to IndexedDB'
+      );
+    }
+
+    return new Promise((resolve, reject) => {
+      const request = this._dbConn
+        .transaction('beams', 'readwrite')
+        .objectStore('beams')
+        .put(state);
+
+      request.onsuccess = _ => {
+        resolve();
+      };
+
+      request.onerror = event => {
+        reject(event.target.error);
+      };
+    });
+  }
+
+  async _writeProperty(name, value) {
+    const state = await this._readState();
+    state[name] = value;
+    await this._writeState(state);
+  }
+
+  getToken() {
+    return this._readProperty('token');
+  }
+
+  setToken(token) {
+    return this._writeProperty('token', token);
+  }
+
+  getDeviceId() {
+    return this._readProperty('device_id');
+  }
+
+  setDeviceId(deviceId) {
+    return this._writeProperty('device_id', deviceId);
+  }
+
+  getUserId() {
+    return this._readProperty('user_id');
+  }
+
+  setUserId(userId) {
+    return this._writeProperty('user_id', userId);
+  }
+}

--- a/src/DeviceStateStore.js
+++ b/src/DeviceStateStore.js
@@ -1,6 +1,5 @@
 export default class DeviceStateStore {
   constructor(instanceId) {
-    this.userId = null;
     this._instanceId = instanceId;
     this._dbConn = null;
   }

--- a/src/push-notifications.test.js
+++ b/src/push-notifications.test.js
@@ -1,24 +1,23 @@
-import { init, Client } from './push-notifications';
+import { init } from './push-notifications';
 
 test('PushNotifications', () => {
   expect(typeof init).toBe('function');
-  expect(typeof Client).toBe('function');
 });
 
 test('Constructor will throw if there is no config object given', () => {
-  expect(() => init()).toThrow('Config object required');
+  expect(init()).rejects.toThrow('Config object required');
 });
 
 test('Constructor will throw if there is no instance ID specified', () => {
-  expect(() => init({})).toThrow('Instance ID is required');
+  expect(init({})).rejects.toThrow('Instance ID is required');
 });
 
 test('Constructor will throw if instance ID is not a string', () => {
   const instanceId = null;
-  expect(() => init({ instanceId })).toThrow('Instance ID must be a string');
+  expect(init({ instanceId })).rejects.toThrow('Instance ID must be a string');
 });
 
 test('Constructor will throw if the instance id is the empty string', () => {
   const instanceId = '';
-  expect(() => init({ instanceId })).toThrow('Instance ID cannot be empty');
+  expect(init({ instanceId })).rejects.toThrow('Instance ID cannot be empty');
 });


### PR DESCRIPTION
I started doing this so that we could get rid of the async constructor for the SDK class - ended up being better to move the state logic out into a separate class.

I want to add tests for the DeviceStateStore - not clear how to do that without some new Selenium stuff though. Will think about this.