### PR TITLE
Make start return the beamsClients so it's easier to chain promises

### DIFF
--- a/end-to-end-tests/sdk-set-user-id.test.js
+++ b/end-to-end-tests/sdk-set-user-id.test.js
@@ -48,14 +48,12 @@ test('SDK should set user id with errol', async () => {
 
   const deviceId = await chromeDriver.executeAsyncScript(() => {
     const asyncScriptReturnCallback = arguments[arguments.length - 1];
-    let beamsClient;
 
     return PusherPushNotifications.init({
       instanceId: '1b880590-6301-4bb5-b34f-45db1c5f5644',
     })
-      .then(c => (beamsClient = c))
-      .then(() => beamsClient.start())
-      .then(() => asyncScriptReturnCallback(beamsClient.deviceId))
+      .then(beamsClient => beamsClient.start())
+      .then(beamsClient => asyncScriptReturnCallback(beamsClient.deviceId))
       .catch(e => asyncScriptReturnCallback(e.message));
   });
 
@@ -84,12 +82,10 @@ test('SDK should set user id with errol', async () => {
       },
     };
 
-    let beamsClient;
     return PusherPushNotifications.init({
       instanceId: '1b880590-6301-4bb5-b34f-45db1c5f5644',
     })
-      .then(c => (beamsClient = c))
-      .then(() => beamsClient.setUserId('cucas', tokenProvider))
+      .then(beamsClient => beamsClient.setUserId('cucas', tokenProvider))
       .then(() => asyncScriptReturnCallback(''))
       .catch(e => asyncScriptReturnCallback(e.message));
   });
@@ -114,13 +110,11 @@ test('SDK should return an error if we try to reassign the user id', async () =>
   const deviceId = await chromeDriver.executeAsyncScript(() => {
     const asyncScriptReturnCallback = arguments[arguments.length - 1];
 
-    let beamsClient;
     return PusherPushNotifications.init({
       instanceId: '1b880590-6301-4bb5-b34f-45db1c5f5644',
     })
-      .then(c => (beamsClient = c))
-      .then(() => beamsClient.start())
-      .then(() => asyncScriptReturnCallback(beamsClient.deviceId))
+      .then(beamsClient => beamsClient.start())
+      .then(beamsClient => asyncScriptReturnCallback(beamsClient.deviceId))
       .catch(e => asyncScriptReturnCallback(e.message));
   });
 

--- a/end-to-end-tests/sdk-start.test.js
+++ b/end-to-end-tests/sdk-start.test.js
@@ -24,11 +24,9 @@ test('SDK should register a device with errol', async () => {
     const asyncScriptReturnCallback = arguments[arguments.length - 1];
 
     const instanceId = 'deadc0de-2ce6-46e3-ad9a-5c02d0ab119b';
-    let beamsClient;
     return PusherPushNotifications.init({ instanceId })
-      .then(c => (beamsClient = c))
-      .then(() => beamsClient.start())
-      .then(() => asyncScriptReturnCallback(beamsClient.deviceId))
+      .then(beamsClient => beamsClient.start())
+      .then(beamsClient => asyncScriptReturnCallback(beamsClient.deviceId))
       .catch(e => asyncScriptReturnCallback(e.message));
   });
 
@@ -45,11 +43,9 @@ test('SDK should remember the device ID', async () => {
     const asyncScriptReturnCallback = arguments[arguments.length - 1];
 
     const instanceId = 'deadc0de-2ce6-46e3-ad9a-5c02d0ab119b';
-    let beamsClient;
     return PusherPushNotifications.init({ instanceId })
-      .then(c => (beamsClient = c))
-      .then(() => beamsClient.start())
-      .then(() => asyncScriptReturnCallback(beamsClient.deviceId))
+      .then(beamsClient => beamsClient.start())
+      .then(beamsClient => asyncScriptReturnCallback(beamsClient.deviceId))
       .catch(e => asyncScriptReturnCallback(e.message));
   });
 
@@ -62,11 +58,9 @@ test('SDK should remember the device ID', async () => {
     const asyncScriptReturnCallback = arguments[arguments.length - 1];
 
     const instanceId = 'deadc0de-2ce6-46e3-ad9a-5c02d0ab119b';
-    let beamsClient;
     return PusherPushNotifications.init({ instanceId })
-      .then(c => (beamsClient = c))
-      .then(() => beamsClient.start())
-      .then(() => asyncScriptReturnCallback(beamsClient.deviceId))
+      .then(beamsClient => beamsClient.start())
+      .then(beamsClient => asyncScriptReturnCallback(beamsClient.deviceId))
       .catch(e => asyncScriptReturnCallback(e.message));
   });
 

--- a/src/push-notifications.js
+++ b/src/push-notifications.js
@@ -89,7 +89,7 @@ class PushNotificationsInstance {
 
   async start() {
     if (this.deviceId !== null) {
-      return;
+      return this;
     }
 
     const { vapidPublicKey: publicKey } = await this._getPublicKey();
@@ -105,6 +105,7 @@ class PushNotificationsInstance {
 
     this.token = token;
     this.deviceId = deviceId;
+    return this;
   }
 
   async setUserId(userId, tokenProvider) {


### PR DESCRIPTION
We often have to daisy-chain the beams client, so this helps.