### PR TITLE
Refactor service worker registration to allow more advance use cases

### DIFF
--- a/end-to-end-tests/sdk-start.test.js
+++ b/end-to-end-tests/sdk-start.test.js
@@ -85,12 +85,12 @@ test('SDK should register a device with errol without registering the service wo
     deleteDbRequest.onsuccess = asyncScriptReturnCallback;
     deleteDbRequest.onerror = asyncScriptReturnCallback;
   });
-  const initialDeviceId = await chromeDriver.executeAsyncScript(() => {
+  const initialDeviceId = await chromeDriver.executeAsyncScript(async () => {
     const asyncScriptReturnCallback = arguments[arguments.length - 1];
 
     const instanceId = 'deadc0de-2ce6-46e3-ad9a-5c02d0ab119b';
     return PusherPushNotifications.init({
-      serviceWorkerRegistration: window.navigator.serviceWorker.register('/service-worker.js'),
+      serviceWorkerRegistration: await window.navigator.serviceWorker.register('/service-worker.js'),
       instanceId,
     })
       .then(beamsClient => beamsClient.start())

--- a/end-to-end-tests/sdk-start.test.js
+++ b/end-to-end-tests/sdk-start.test.js
@@ -67,6 +67,40 @@ test('SDK should remember the device ID', async () => {
   expect(reloadedDeviceId).toBe(initialDeviceId);
 });
 
+
+test('SDK should register a device with errol without registering the service worker itself', async () => {
+  // this is the case where customers want to manage the service worker themselves
+  await chromeDriver.get('http://localhost:3000');
+  await chromeDriver.wait(() => {
+    return chromeDriver.getTitle().then(title => title.includes('Test Page'));
+  }, 2000);
+
+  // make sure there device isn't there
+  await chromeDriver.executeAsyncScript(() => {
+    const asyncScriptReturnCallback = arguments[arguments.length - 1];
+
+    let deleteDbRequest = window.indexedDB.deleteDatabase(
+      'beams-deadc0de-2ce6-46e3-ad9a-5c02d0ab119b'
+    );
+    deleteDbRequest.onsuccess = asyncScriptReturnCallback;
+    deleteDbRequest.onerror = asyncScriptReturnCallback;
+  });
+  const initialDeviceId = await chromeDriver.executeAsyncScript(() => {
+    const asyncScriptReturnCallback = arguments[arguments.length - 1];
+
+    const instanceId = 'deadc0de-2ce6-46e3-ad9a-5c02d0ab119b';
+    return PusherPushNotifications.init({
+      serviceWorkerRegistration: window.navigator.serviceWorker.register('/service-worker.js'),
+      instanceId,
+    })
+      .then(beamsClient => beamsClient.start())
+      .then(beamsClient => asyncScriptReturnCallback(beamsClient.deviceId))
+      .catch(e => asyncScriptReturnCallback(e.message));
+  });
+
+  expect(initialDeviceId).toContain('web-');
+});
+
 afterAll(() => {
   if (killServer) {
     killServer();

--- a/package-lock.json
+++ b/package-lock.json
@@ -5975,6 +5975,15 @@
         }
       }
     },
+    "rollup-plugin-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-json/-/rollup-plugin-json-4.0.0.tgz",
+      "integrity": "sha512-hgb8N7Cgfw5SZAkb3jf0QXii6QX/FOkiIq2M7BAQIEydjHvTyxXHQiIzZaTFgx1GK0cRCHOCBHIyEkkLdWKxow==",
+      "dev": true,
+      "requires": {
+        "rollup-pluginutils": "^2.5.0"
+      }
+    },
     "rollup-plugin-node-resolve": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "rollup": "^1.10.0",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^9.3.4",
+    "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-node-resolve": "^4.2.3",
     "selenium-webdriver": "^4.0.0-alpha.3"
   },

--- a/rollup/cdn.js
+++ b/rollup/cdn.js
@@ -1,6 +1,7 @@
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import babel from 'rollup-plugin-babel';
+import json from 'rollup-plugin-json';
 
 export default [
   {
@@ -11,6 +12,7 @@ export default [
       format: 'iife',
     },
     plugins: [
+      json(),
       resolve(),
       commonjs(),
       babel({

--- a/rollup/esm.js
+++ b/rollup/esm.js
@@ -1,6 +1,7 @@
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import babel from 'rollup-plugin-babel';
+import json from 'rollup-plugin-json';
 
 export default [
   {
@@ -10,6 +11,7 @@ export default [
       format: 'esm',
     },
     plugins: [
+      json(),
       resolve(),
       commonjs(),
       babel({

--- a/src/push-notifications.js
+++ b/src/push-notifications.js
@@ -2,7 +2,7 @@ import doRequest from './doRequest';
 import TokenProvider from './token-provider';
 import DeviceStateStore from './DeviceStateStore';
 
-const DEFAULT_SERVICE_WORKER_URL = '/service-worker.js';
+const SERVICE_WORKER_URL = '/service-worker.js';
 
 export async function init(config) {
   if (!config) {
@@ -11,7 +11,7 @@ export async function init(config) {
   const {
     instanceId,
     endpointOverride = null,
-    serviceWorkerURL = DEFAULT_SERVICE_WORKER_URL,
+    serviceWorkerRegistration = null,
   } = config;
 
   if (instanceId === undefined) {
@@ -54,7 +54,7 @@ export async function init(config) {
     deviceId,
     token,
     userId,
-    serviceWorkerURL,
+    serviceWorkerRegistration,
     deviceStateStore,
     endpointOverride,
   });
@@ -66,7 +66,7 @@ class PushNotificationsInstance {
     deviceId,
     token,
     userId,
-    serviceWorkerURL,
+    serviceWorkerRegistration,
     deviceStateStore,
     endpointOverride = null,
   }) {
@@ -74,7 +74,7 @@ class PushNotificationsInstance {
     this.deviceId = deviceId;
     this.token = token;
     this.userId = userId;
-    this._serviceWorkerUrl = serviceWorkerURL;
+    this._serviceWorkerRegistration = serviceWorkerRegistration;
     this._deviceStateStore = deviceStateStore;
 
     this._endpoint = endpointOverride; // Internal only
@@ -157,7 +157,16 @@ class PushNotificationsInstance {
 
   async _getPushToken(publicKey) {
     try {
-      window.navigator.serviceWorker.register(this._serviceWorkerUrl);
+      if (this._serviceWorkerRegistration) {
+        // TODO: Call update only when we detect an SDK change
+      } else {
+        window.navigator.serviceWorker.register(SERVICE_WORKER_URL, {
+          // explicitly opting out of `importScripts` caching just in case our
+          // customers decides to host and serve the imported scripts and
+          // accidentally set `Cache-Control` to something other than `max-age=0`
+          updateViaCache: 'none',
+        });
+      }
       const reg = await window.navigator.serviceWorker.ready;
       const sub = await reg.pushManager.subscribe({
         userVisibleOnly: true,

--- a/src/push-notifications.js
+++ b/src/push-notifications.js
@@ -1,8 +1,9 @@
 import doRequest from './doRequest';
 import TokenProvider from './token-provider';
 import DeviceStateStore from './DeviceStateStore';
+import { version as sdkVersion } from 'package.json';
 
-const SERVICE_WORKER_URL = '/service-worker.js';
+const SERVICE_WORKER_URL = `/service-worker.js?pusherBeamsWebSDKVersion=${sdkVersion}`;
 
 export async function init(config) {
   if (!config) {

--- a/src/push-notifications.js
+++ b/src/push-notifications.js
@@ -1,7 +1,7 @@
 import doRequest from './doRequest';
 import TokenProvider from './token-provider';
 import DeviceStateStore from './DeviceStateStore';
-import { version as sdkVersion } from 'package.json';
+import { version as sdkVersion } from '../package.json';
 
 const SERVICE_WORKER_URL = `/service-worker.js?pusherBeamsWebSDKVersion=${sdkVersion}`;
 


### PR DESCRIPTION
We either manage the service-worker file entirely as we best see fit or we delegate the registration to the customer and call `update` in the SDK.

This `update` functionality is currently missing, but this is something we can always add in a later release.