### PR TITLE
Return clear error message when service worker is in incorrect scope

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
         - npm run build:cdn
         - npm run test:e2e
       before_script:
-        - wget https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip
+        - wget https://chromedriver.storage.googleapis.com/77.0.3865.40/chromedriver_linux64.zip
         - unzip chromedriver_linux64.zip
         - sudo mv chromedriver /usr/local/bin
         - sh -e /etc/init.d/xvfb start

--- a/end-to-end-tests/test-app/server.js
+++ b/end-to-end-tests/test-app/server.js
@@ -33,4 +33,10 @@ app.get('/service-worker.js', (req, res) => {
   }
 });
 
+// Service worker in unusual location
+app.get('/not-the-root/service-worker.js', (req, res) => {
+  res.set('Content-Type', 'text/javascript');
+  res.send('');
+});
+
 app.listen(PORT, () => console.log(`Listening on port ${PORT}...`));


### PR DESCRIPTION
# Issue
The SDK would fail silently if a service worker registration is passed in with the wrong scope

# Fix
 - Don't wait on the incoming registration (it may never be ready)
 - Raise a descriptive error if a registration is passed in with a bad scope