### PR TITLE
Notification handling support

### DIFF
--- a/end-to-end-tests/test-utils.js
+++ b/end-to-end-tests/test-utils.js
@@ -18,7 +18,7 @@ const CHROME_SCREEN_SIZE = {
 const CHROME_CONFIG_TEMP_DIR = `${__dirname}/temp`;
 
 beforeAll(() => {
-  jest.setTimeout(30000);
+  jest.setTimeout(60000);
 });
 
 /**

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -12,7 +12,7 @@ self.addEventListener('push', e => {
     return; // Not a pusher notification
   }
 
-  if (!payload.data.pusher) {
+  if (!payload.data || !payload.data.pusher) {
     return; // Not a pusher notification
   }
 

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,33 +1,63 @@
 /* eslint-env serviceworker */
 
-self.addEventListener('push', function(e) {
-  const payload = e.data.json();
+const PusherPushNotifications = {
+  onNotificationReceived: null,
+};
 
-  const title = payload.notification.title || '';
-  const body = payload.notification.body || '';
-  const icon = payload.notification.icon;
-  const data = payload.data || {};
-
-  if (payload.notification.deep_link) {
-    // Copying the deep_link into the data payload so that it can
-    // be accessed in the notificationclick handler.
-    data.pusher.deep_link = payload.notification.deep_link;
+self.addEventListener('push', e => {
+  let payload;
+  try {
+    payload = e.data.json();
+  } catch (_) {
+    return; // Not a pusher notification
   }
 
-  const options = {
-    title,
-    body,
-    icon,
-    data,
+  if (!payload.data.pusher) {
+    return; // Not a pusher notification
+  }
+
+  const customerPayload = { ...payload };
+  const customerData = {};
+  Object.keys(customerPayload.data || {}).forEach(key => {
+    if (key !== 'pusher') {
+      customerData[key] = customerPayload.data[key];
+    }
+  });
+  customerPayload.data = customerData;
+
+  const handleNotification = payload => {
+    const title = payload.notification.title || '';
+    const body = payload.notification.body || '';
+    const icon = payload.notification.icon;
+
+    const options = {
+      title,
+      body,
+      icon,
+      data: { payload },
+    };
+
+    e.waitUntil(self.registration.showNotification(title, options));
   };
 
-  e.waitUntil(self.registration.showNotification(title, options));
+  if (PusherPushNotifications.onNotificationReceived) {
+    PusherPushNotifications.onNotificationReceived({
+      payload: customerPayload,
+      handleNotification,
+    });
+  } else {
+    handleNotification(payload);
+  }
 });
 
-self.addEventListener('notificationclick', function(event) {
-  const deep_link = event.notification.data.pusher.deep_link;
-  if (deep_link) {
-    event.waitUntil(clients.openWindow(deep_link));
+self.addEventListener('notificationclick', event => {
+  const { payload } = event.notification.data;
+
+  const isPusherNotification = payload !== undefined;
+  if (isPusherNotification) {
+    if (payload.notification.deep_link) {
+      event.waitUntil(clients.openWindow(payload.notification.deep_link));
+    }
+    event.notification.close();
   }
-  event.notification.close();
 });

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -41,6 +41,7 @@ self.addEventListener('push', e => {
   if (self.PusherPushNotifications.onNotificationReceived) {
     self.PusherPushNotifications.onNotificationReceived({
       payload: customerPayload,
+      pushEvent: e,
       handleNotification,
     });
   } else {
@@ -48,14 +49,14 @@ self.addEventListener('push', e => {
   }
 });
 
-self.addEventListener('notificationclick', event => {
-  const { pusherPayload: payload } = event.notification.data;
+self.addEventListener('notificationclick', e => {
+  const { pusherPayload: payload } = e.notification.data;
 
   const isPusherNotification = payload !== undefined;
   if (isPusherNotification) {
     if (payload.notification.deep_link) {
-      event.waitUntil(clients.openWindow(payload.notification.deep_link));
+      e.waitUntil(clients.openWindow(payload.notification.deep_link));
     }
-    event.notification.close();
+    e.notification.close();
   }
 });

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -38,8 +38,8 @@ self.addEventListener('push', e => {
     e.waitUntil(self.registration.showNotification(title, options));
   };
 
-  if (PusherPushNotifications.onNotificationReceived) {
-    PusherPushNotifications.onNotificationReceived({
+  if (self.PusherPushNotifications.onNotificationReceived) {
+    self.PusherPushNotifications.onNotificationReceived({
       payload: customerPayload,
       handleNotification,
     });

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -30,7 +30,6 @@ self.addEventListener('push', e => {
     const icon = payload.notification.icon;
 
     const options = {
-      title,
       body,
       icon,
       data: { pusherPayload: payload },

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,6 +1,5 @@
 /* eslint-env serviceworker */
-
-const PusherPushNotifications = {
+self.PusherPushNotifications = {
   onNotificationReceived: null,
 };
 

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -34,7 +34,7 @@ self.addEventListener('push', e => {
       title,
       body,
       icon,
-      data: { payload },
+      data: { pusherPayload: payload },
     };
 
     e.waitUntil(self.registration.showNotification(title, options));
@@ -51,7 +51,7 @@ self.addEventListener('push', e => {
 });
 
 self.addEventListener('notificationclick', event => {
-  const { payload } = event.notification.data;
+  const { pusherPayload: payload } = event.notification.data;
 
   const isPusherNotification = payload !== undefined;
   if (isPusherNotification) {

--- a/src/service-worker.test.js
+++ b/src/service-worker.test.js
@@ -1,0 +1,51 @@
+const makePushEvent = payload => ({
+  data: {
+    json: () => JSON.parse(payload),
+  },
+});
+
+let listeners = {};
+let sentNotifications = [];
+
+beforeEach(() => {
+  listeners = {};
+  global.addEventListener = (name, func) => {
+    listeners[name] = func;
+  };
+  global.registration = {
+    showNotification: (title, options) =>
+      sentNotifications.append({ title, options }),
+  };
+
+  jest.resetModules();
+});
+
+describe('SW should ignore notification when', () => {
+  test.each([
+    ['payload is not a json object', '£)$*£()*A)(£*$£('],
+    ['payload has no data field', '{"key": "value"}'],
+    ['payload has no pusher field', '{"data": {}}'],
+  ])('%s', (_, payload) => {
+    const sw = require('./service-worker.js');
+    const PusherPushNotifications = global.PusherPushNotifications;
+
+    // Given an onNotificationReceived had been set
+    let onNotificationReceivedCalled = false;
+    PusherPushNotifications.onNotificationReceived = () => {
+      onNotificationReceivedCalled = true;
+    };
+
+    // When the push listener is called
+    const pushListener = listeners['push'];
+    if (!pushListener) {
+      throw new Error('No push listener has been set');
+    }
+    pushListener(makePushEvent(payload));
+
+    // Then a notification should NOT be shown
+    expect(sentNotifications).toHaveLength(0);
+
+    // And the onNotificationReceived handler should NOT be called
+    expect(onNotificationReceivedCalled).toBe(false);
+  });
+});

--- a/src/service-worker.test.js
+++ b/src/service-worker.test.js
@@ -29,7 +29,7 @@ describe('SW should ignore notification when', () => {
     ['payload has no data field', '{"key": "value"}'],
     ['payload has no pusher field', '{"data": {}}'],
   ])('%s', (_, payload) => {
-    const sw = require('./service-worker.js');
+    require('./service-worker.js');
     const PusherPushNotifications = global.PusherPushNotifications;
 
     // Given an onNotificationReceived had been set
@@ -54,7 +54,7 @@ describe('SW should ignore notification when', () => {
 });
 
 test('SW should show notification when it comes from Pusher', () => {
-  const sw = require('./service-worker.js');
+  require('./service-worker.js');
 
   // Given a push event that comes from Pusher
   const pushEvent = makePushEvent(`

--- a/src/service-worker.test.js
+++ b/src/service-worker.test.js
@@ -103,3 +103,43 @@ test('SW should show notification when it comes from Pusher', () => {
     },
   });
 });
+
+test('SW should NOT show notification if onNotificationReceived handler is set', () => {
+  require('./service-worker.js');
+  const PusherPushNotifications = global.PusherPushNotifications;
+
+  // Given a push event that comes from Pusher
+  const pushEvent = makePushEvent(`
+      {
+        "notification": {
+          "title": "Hi!",
+          "body": "This is a notification!",
+          "icon": "my-icon.png"
+        },
+        "data": {
+          "pusher": {
+            "publishId": "some-publish-id"
+          }
+        }
+      }
+    `);
+
+  // And an onNotificationReceived had been set
+  let onNotificationReceivedCalled = false;
+  PusherPushNotifications.onNotificationReceived = () => {
+    onNotificationReceivedCalled = true;
+  };
+
+  // When the push listener is called
+  const pushListener = listeners['push'];
+  if (!pushListener) {
+    throw new Error('No push listener has been set');
+  }
+  pushListener(pushEvent);
+
+  // Then a notification should NOT be shown
+  expect(shownNotifications).toHaveLength(0);
+
+  // And the onNotificationReceived handler should be called
+  expect(onNotificationReceivedCalled).toBe(true);
+});


### PR DESCRIPTION
We need a way for customers to use custom logic for handling incoming notifications to suit their use case.
This PR offers a mechanism for customers to override the default behaviour entirely. We can use this to learn about their use cases and implement dedicated helpers in future.