### PR TITLE
Clear the push token when the SDK is stopped

### DIFF
--- a/src/push-notifications.js
+++ b/src/push-notifications.js
@@ -218,8 +218,8 @@ class PushNotificationsInstance {
     }
 
     await this._deleteDevice();
-
     await this._deviceStateStore.clear();
+    this._clearPushToken().catch(() => {}); // Not awaiting this, best effort.
 
     this.deviceId = null;
     this.token = null;
@@ -250,6 +250,9 @@ class PushNotificationsInstance {
 
   async _getPushToken(publicKey) {
     try {
+      // The browser might already have a push subscription to different key.
+      // Lets clear it out first.
+      await this._clearPushToken();
       const sub = await this._serviceWorkerRegistration.pushManager.subscribe({
         userVisibleOnly: true,
         applicationServerKey: urlBase64ToUInt8Array(publicKey),
@@ -258,6 +261,14 @@ class PushNotificationsInstance {
     } catch (e) {
       return Promise.reject(e);
     }
+  }
+
+  async _clearPushToken() {
+    return navigator.serviceWorker.ready
+      .then(reg => reg.pushManager.getSubscription())
+      .then(sub => {
+        if (sub) sub.unsubscribe();
+      });
   }
 
   async _registerDevice(token) {


### PR DESCRIPTION
By not unsubscribing from the push gateway when the SDK is stopped, we make it impossible to restart the SDK using another instance because that instance will have a different set of vapid keys