### PR TITLE
Secure context error

### DIFF
--- a/src/push-notifications.js
+++ b/src/push-notifications.js
@@ -35,6 +35,12 @@ export async function init(config) {
     );
   }
 
+  if(!window.isSecureContext) {
+    throw new Error(
+      'Pusher Beams can only be used in a secure context. Ensure your page is being served over HTTPS (Not loaded from a secure context)'
+    );
+  }
+
   if (!('serviceWorker' in navigator)) {
     throw new Error(
       'Pusher Beams does not support this browser version (Service Workers not supported)'

--- a/src/push-notifications.js
+++ b/src/push-notifications.js
@@ -35,9 +35,9 @@ export async function init(config) {
     );
   }
 
-  if(!window.isSecureContext) {
+  if (!window.isSecureContext) {
     throw new Error(
-      'Pusher Beams can only be used in a secure context. Ensure your page is being served over HTTPS (Not loaded from a secure context)'
+      'Pusher Beams can only be used in a secure context. Check that your page is being served over HTTPS. (Not loaded from a secure context)'
     );
   }
 

--- a/src/push-notifications.js
+++ b/src/push-notifications.js
@@ -37,7 +37,7 @@ export async function init(config) {
 
   if (!window.isSecureContext) {
     throw new Error(
-      'Pusher Beams can only be used in a secure context. Check that your page is being served over HTTPS. (Not loaded from a secure context)'
+      'Pusher Beams can only be used in a secure context. Check that your page is being served over HTTPS'
     );
   }
 

--- a/src/push-notifications.js
+++ b/src/push-notifications.js
@@ -37,7 +37,7 @@ export async function init(config) {
 
   if (!window.isSecureContext) {
     throw new Error(
-      'Pusher Beams can only be used in a secure context. Check that your page is being served over HTTPS'
+      'Pusher Beams relies on Service Workers, which only work in secure contexts. Check that your page is being served from localhost/over HTTPS'
     );
   }
 

--- a/src/push-notifications.test.js
+++ b/src/push-notifications.test.js
@@ -51,7 +51,7 @@ describe('Constructor', () => {
     setUpGlobals({ isSecureContext: false });
     const instanceId = 'df3c1965-e870-4bd6-8d75-fea56b26335f';
     return expect(PusherPushNotifications.init({ instanceId })).rejects.toThrow(
-      'Not loaded from a secure context'
+      'Pusher Beams can only be used in a secure context'
     );
   });
 

--- a/src/push-notifications.test.js
+++ b/src/push-notifications.test.js
@@ -47,6 +47,14 @@ describe('Constructor', () => {
     );
   });
 
+  test('will throw if the SDK is loaded from a context that is not secure', () => {
+    setUpGlobals({ isSecureContext: false });
+    const instanceId = 'df3c1965-e870-4bd6-8d75-fea56b26335f';
+    return expect(PusherPushNotifications.init({ instanceId })).rejects.toThrow(
+      'Not loaded from a secure context'
+    );
+  });
+
   test('will throw if ServiceWorkerRegistration not supported', () => {
     setUpGlobals({ serviceWorkerSupport: false });
     const instanceId = 'df3c1965-e870-4bd6-8d75-fea56b26335f';
@@ -463,6 +471,7 @@ const setUpGlobals = ({
   indexedDBSupport = true,
   serviceWorkerSupport = true,
   webPushSupport = true,
+  isSecureContext = true,
 }) => {
   if (indexedDBSupport) {
     global.window.indexedDB = {};
@@ -479,6 +488,7 @@ const setUpGlobals = ({
   if (webPushSupport) {
     global.window.PushManager = {};
   }
+  global.window.isSecureContext = isSecureContext;
 };
 
 const tearDownGlobals = () => {

--- a/src/push-notifications.test.js
+++ b/src/push-notifications.test.js
@@ -51,7 +51,7 @@ describe('Constructor', () => {
     setUpGlobals({ isSecureContext: false });
     const instanceId = 'df3c1965-e870-4bd6-8d75-fea56b26335f';
     return expect(PusherPushNotifications.init({ instanceId })).rejects.toThrow(
-      'Pusher Beams can only be used in a secure context'
+      'Pusher Beams relies on Service Workers, which only work in secure contexts'
     );
   });
 


### PR DESCRIPTION
Loading the library in an insecure context (e.g. not over HTTPS) currently throws the following misleading error:
`Pusher Beams does not support this browser version (Service Workers not supported)`

This PR adds a more appropriate error.