### PR TITLE
Experiment: hide notification based on deep link or URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pusher/push-notifications-web",
-  "version": "0.9.2",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8236,6 +8236,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "urijs": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.2.tgz",
+      "integrity": "sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w==",
+      "dev": true
     },
     "urix": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-node-resolve": "^4.2.3",
-    "selenium-webdriver": "^4.0.0-alpha.3"
+    "selenium-webdriver": "^4.0.0-alpha.3",
+    "urijs": "^1.19.2"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
We could trigger notifications with a payload like this:
```
 web: {
      notification: {
        title: '🍕 Pusher Pizza',
        body: 'Pizza status: ' + state,
        deep_link: '/?id='+id,
        hide_notification_if_page_has_focus: {
          mode: "deep_link",
          ignore_all_query_parameters: false,
          ignore_fragment: false,
          ignore_protocol: false,
        },
        icon: 'http://localhost:3000/icon_128x128@2x.png'
      }
    }
```
And notifications won't show if the "deep_link" page is open.