### PR TITLE
Fix SDK state bug

### DIFF
--- a/src/push-notifications.test.js
+++ b/src/push-notifications.test.js
@@ -644,10 +644,10 @@ describe('SDK state', () => {
     const PusherPushNotifications = require('./push-notifications');
     const devicestatestore = require('./device-state-store');
 
-    let state = { subscription: DUMMY_PUSH_SUBSCRIPTION };
+    let subscription = DUMMY_PUSH_SUBSCRIPTION;
     setUpGlobals({
       getSWSubscription: () => {
-        return Promise.resolve(state.subscription);
+        return Promise.resolve(subscription);
       },
     });
 
@@ -674,7 +674,7 @@ describe('SDK state', () => {
       })
       .then(() => {
         // Change subscription
-        state.subscription = newSubscription;
+        subscription = newSubscription;
       })
       .then(() => beamsClient.getDeviceId())
       .then(deviceId => {


### PR DESCRIPTION
If the browser notification permissions are changed while the page is open then the state returned by the `getRegistrationState` method will be incorrect. The SDK will still be in the "registered with Beams" state despite not having the browser permission, which is not one of the possible states returned by `getRegistrationState`.

This PR fixes that by reconciling the SDK state before any access of the SDK. In the future, we may add listeners to allow users to detect changes in state.