### PR TITLE
Fix bug where analytics timestamps were sent as floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/pusher/push-notifications-web/compare/1.0.0...HEAD)
+- Fix bug in service worker which generated invalid open/delivery events due to
+  non-integer timestamps
 
 ## [1.0.0](https://github.com/pusher/push-notifications-web/compare/0.9.0...1.0.0) - 2020-07-22
 

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -69,7 +69,7 @@ self.PusherPushNotifications = {
         event: eventType,
         deviceId,
         userId,
-        timestampSecs: Date.now() / 1000,
+        timestampSecs: Math.floor(Date.now() / 1000),
         appInBackground,
         hasDisplayableContent,
         hasData,


### PR DESCRIPTION
The service worker was sending timestamps as floats when the event was not sent on the second.
This causes validation errors on the server because the timestamp field is typed as a float.

This PR rounds the timetamps down to the nearest second.﻿
