### PR TITLE
Await the provided service worker on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/pusher/push-notifications-web/compare/1.0.1...HEAD)
+ - Fix bug in SDK where we weren't waiting for custom Service Workers to become
+   ready before starting the SDK
 
 ## [1.0.2](https://github.com/pusher/push-notifications-web/compare/1.0.1...1.0.2) - 2020-08-24
 - Fix bug in service worker where analytics events would cause runtime errors

--- a/src/push-notifications.js
+++ b/src/push-notifications.js
@@ -92,7 +92,11 @@ export class Client {
 
     await this._deviceStateStore.connect();
 
-    if (!this._serviceWorkerRegistration) {
+    if (this._serviceWorkerRegistration) {
+      // If we have been given a service worker, wait for it to be ready
+      await window.navigator.serviceWorker.ready;
+    } else {
+      // Otherwise register our own one
       this._serviceWorkerRegistration = await getServiceWorkerRegistration();
     }
 


### PR DESCRIPTION
We weren't awaiting custom service workers when one was provided.
This meant that the SDK would return bad state whilst the service worker was registering.

This PR awaits the provided sw in _init so that other methods will block until it is ready﻿
