### PR TITLE
Split register device methods

### DIFF
--- a/src/base-client.js
+++ b/src/base-client.js
@@ -180,18 +180,10 @@ export default class BaseClient {
     await this._deviceStateStore.setLastSeenUserAgent(userAgent);
   }
 
-  async _registerDevice(token) {
+  async _registerDevice(device) {
     const path = `${this._baseURL}/device_api/v1/instances/${encodeURIComponent(
       this.instanceId
     )}/devices/${this._platform}`;
-
-    const device = {
-      token,
-      metadata: {
-        sdkVersion,
-      },
-    };
-
     const options = { method: 'POST', path, body: device };
     const response = await doRequest(options);
     return response.id;

--- a/src/safari-client.js
+++ b/src/safari-client.js
@@ -100,7 +100,10 @@ export class SafariClient extends BaseClient {
       console.debug('permission is default, requesting permission');
       let { deviceToken, permission } = await this._requestPermission(__pushId);
       if (permission == 'granted') {
-        const deviceId = await this._registerDevice(deviceToken);
+        const deviceId = await this._registerDevice(
+          deviceToken,
+          this._websitePushId
+        );
         await this._deviceStateStore.setToken(deviceToken);
         await this._deviceStateStore.setDeviceId(deviceId);
         await this._deviceStateStore.setLastSeenSdkVersion(sdkVersion);
@@ -206,6 +209,16 @@ export class SafariClient extends BaseClient {
     this._deviceId = null;
     this._token = null;
     this._userId = null;
+  }
+
+  async _registerDevice(token, websitePushId) {
+    return await super._registerDevice({
+      token,
+      websitePushId,
+      metadata: {
+        sdkVersion,
+      },
+    });
   }
 }
 

--- a/src/web-push-client.js
+++ b/src/web-push-client.js
@@ -266,6 +266,15 @@ export class WebPushClient extends BaseClient {
         if (sub) sub.unsubscribe();
       });
   }
+
+  async _registerDevice(token) {
+    return await super._registerDevice({
+      token,
+      metadata: {
+        sdkVersion,
+      },
+    });
+  }
 }
 
 async function getServiceWorkerRegistration() {


### PR DESCRIPTION
Safari devices registering with Beams will need to provide the `websitePushId`, so split the device registration method to allow this.