### PR TITLE
Is supported method

### DIFF
--- a/src/base-client.js
+++ b/src/base-client.js
@@ -261,7 +261,7 @@ export default class BaseClient {
 
     const path = `${this._baseURL}/device_api/v1/instances/${encodeURIComponent(
       this.instanceId
-    )}/devices/web/${this._deviceId}/user`;
+    )}/devices/${this._platform}/${this._deviceId}/user`;
 
     const { token: beamsAuthToken } = await tokenProvider.fetchToken(userId);
     const options = {

--- a/src/push-notifications.js
+++ b/src/push-notifications.js
@@ -4,10 +4,17 @@ import TokenProvider from './token-provider';
 import { RegistrationState } from './base-client';
 
 function Client(config) {
-  if ('safari' in window) {
+  if (isSafari()) {
     return new SafariClient(config);
   }
   return new WebPushClient(config);
+}
+
+function isSafari() {
+  return (
+    window.navigator.userAgent.indexOf('Safari') > -1 &&
+    window.navigator.userAgent.indexOf('Chrome') === -1
+  );
 }
 
 export { Client, RegistrationState, TokenProvider };

--- a/src/push-notifications.test.js
+++ b/src/push-notifications.test.js
@@ -44,32 +44,6 @@ describe('Constructor', () => {
     ).toThrow('IndexedDB not supported');
   });
 
-  test('will throw if the SDK is loaded from a context that is not secure', () => {
-    setUpGlobals({ isSecureContext: false });
-    const instanceId = 'df3c1965-e870-4bd6-8d75-fea56b26335f';
-    return expect(
-      () => new PusherPushNotifications.Client({ instanceId })
-    ).toThrow(
-      'Pusher Beams relies on Service Workers, which only work in secure contexts'
-    );
-  });
-
-  test('will throw if ServiceWorkerRegistration not supported', () => {
-    setUpGlobals({ serviceWorkerSupport: false });
-    const instanceId = 'df3c1965-e870-4bd6-8d75-fea56b26335f';
-    return expect(
-      () => new PusherPushNotifications.Client({ instanceId })
-    ).toThrow('Service Workers not supported');
-  });
-
-  test('will throw if Web Push not supported', () => {
-    setUpGlobals({ webPushSupport: false });
-    const instanceId = 'df3c1965-e870-4bd6-8d75-fea56b26335f';
-    return expect(
-      () => new PusherPushNotifications.Client({ instanceId })
-    ).toThrow('Web Push not supported');
-  });
-
   test('will return properly configured instance otherwise', () => {
     const PusherPushNotifications = require('./push-notifications');
     const devicestatestore = require('./device-state-store');
@@ -681,6 +655,44 @@ describe('SDK state', () => {
         // Device ID should have been cleared
         return expect(deviceId).toBeNull();
       });
+  });
+});
+
+describe('.browserIsSupported', () => {
+  afterEach(() => {
+    jest.resetModules();
+    tearDownGlobals();
+  });
+  test('will resolve to false if the SDK is loaded from a context that is not secure', () => {
+    setUpGlobals({ isSecureContext: false });
+    const instanceId = 'df3c1965-e870-4bd6-8d75-fea56b26335f';
+    const client = new PusherPushNotifications.Client({ instanceId });
+    return client.isSupportedBrowser().then(result => {
+      expect(result).toEqual(false);
+      expect(client.error).toMatch(
+        'Pusher Beams relies on Service Workers, which only work in secure contexts'
+      );
+    });
+  });
+
+  test('will resolve to false if ServiceWorkerRegistration not supported', () => {
+    setUpGlobals({ serviceWorkerSupport: false });
+    const instanceId = 'df3c1965-e870-4bd6-8d75-fea56b26335f';
+    const client = new PusherPushNotifications.Client({ instanceId });
+    return client.isSupportedBrowser().then(result => {
+      expect(result).toEqual(false);
+      expect(client.error).toMatch('Service Workers not supported');
+    });
+  });
+
+  test('will resolve to false if Web Push not supported', () => {
+    setUpGlobals({ webPushSupport: false });
+    const instanceId = 'df3c1965-e870-4bd6-8d75-fea56b26335f';
+    const client = new PusherPushNotifications.Client({ instanceId });
+    return client.isSupportedBrowser().then(result => {
+      expect(result).toEqual(false);
+      expect(client.error).toMatch('Web Push not supported');
+    });
   });
 });
 

--- a/src/safari-client.js
+++ b/src/safari-client.js
@@ -20,7 +20,7 @@ export class SafariClient extends BaseClient {
   async _init() {
     this._websitePushId = await this._fetchWebsitePushId();
     if (this._websitePushId === null) {
-      return
+      return;
     }
     this._serviceUrl = `${
       this._baseURL
@@ -174,6 +174,16 @@ export class SafariClient extends BaseClient {
 
   _isSupportedBrowser() {
     return 'safari' in window && 'pushNotification' in window.safari;
+  }
+
+  // Checks whether the browser is supported, but also whether the instance has
+  // safari credentials configured
+  async isSupportedBrowser() {
+    if (!this._isSupportedBrowser()) {
+      return false;
+    }
+    await this._ready;
+    return this._websitePushId != null;
   }
 }
 

--- a/src/web-push-client.js
+++ b/src/web-push-client.js
@@ -230,6 +230,12 @@ export class WebPushClient extends BaseClient {
     }
     return isSupported;
   }
+
+  // This method doesn't do anything asynchronous, but the safari equivalent
+  // does and the API should be the same
+  async isSupportedBrowser() {
+    return this._isSupportedBrowser();
+  }
 }
 
 async function getServiceWorkerRegistration() {

--- a/src/web-push-client.js
+++ b/src/web-push-client.js
@@ -36,8 +36,9 @@ export class WebPushClient extends BaseClient {
       const currentURL = window.location.href;
       const scopeMatchesCurrentPage = currentURL.startsWith(serviceWorkerScope);
       if (!scopeMatchesCurrentPage) {
-        this.error = `Could not initialize Pusher web push: current page not in serviceWorkerRegistration scope (${serviceWorkerScope})`;
-        return;
+        throw new Error(
+          `Could not initialize Pusher web push: current page not in serviceWorkerRegistration scope (${serviceWorkerScope})`
+        );
       }
     }
     this._serviceWorkerRegistration = serviceWorkerRegistration;

--- a/src/web-push-client.js
+++ b/src/web-push-client.js
@@ -10,22 +10,23 @@ export class WebPushClient extends BaseClient {
   constructor(config) {
     super(config, platform);
 
+    this.error = null;
     if (!window.isSecureContext) {
-      throw new Error(
-        'Pusher Beams relies on Service Workers, which only work in secure contexts. Check that your page is being served from localhost/over HTTPS'
-      );
+      this.error =
+        'Pusher Beams relies on Service Workers, which only work in secure contexts. Check that your page is being served from localhost/over HTTPS';
+      return;
     }
 
     if (!('serviceWorker' in navigator)) {
-      throw new Error(
-        'Pusher Beams does not support this browser version (Service Workers not supported)'
-      );
+      this.error =
+        'Pusher Beams does not support this browser version (Service Workers not supported)';
+      return;
     }
 
     if (!('PushManager' in window)) {
-      throw new Error(
-        'Pusher Beams does not support this browser version (Web Push not supported)'
-      );
+      this.error =
+        'Pusher Beams does not support this browser version (Web Push not supported)';
+      return;
     }
 
     const { serviceWorkerRegistration = null } = config;
@@ -35,9 +36,8 @@ export class WebPushClient extends BaseClient {
       const currentURL = window.location.href;
       const scopeMatchesCurrentPage = currentURL.startsWith(serviceWorkerScope);
       if (!scopeMatchesCurrentPage) {
-        throw new Error(
-          `Could not initialize Pusher web push: current page not in serviceWorkerRegistration scope (${serviceWorkerScope})`
-        );
+        this.error = `Could not initialize Pusher web push: current page not in serviceWorkerRegistration scope (${serviceWorkerScope})`;
+        return;
       }
     }
     this._serviceWorkerRegistration = serviceWorkerRegistration;
@@ -231,10 +231,9 @@ export class WebPushClient extends BaseClient {
     return isSupported;
   }
 
-  // This method doesn't do anything asynchronous, but the safari equivalent
-  // does and the API should be the same
   async isSupportedBrowser() {
-    return this._isSupportedBrowser();
+    await this._ready;
+    return this.error === null;
   }
 }
 


### PR DESCRIPTION
Only throw errors for configuration errors, not compatibility errors. If there is an incompatiblity error (either the browser does not support web push or something, or safari credentials don't exist for the instance) return `false` from `isSupportedBrowser()` and expose details in `client.error`
```
beamsClient.isSupportedBrowser().then((result) => {
  if (!result) {
    console.log(`Beams not supported: ${beamsClient.error}`);
    return
  }
  renderPushNotificationsButton(beamsClient);
});
```