### PR TITLE
deep_link: Focus existing window

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -164,10 +164,22 @@ self.addEventListener('notificationclick', e => {
       pusherMetadata: pusher.pusherMetadata,
     });
 
-    if (pusher.customerPayload.notification.deep_link) {
-      e.waitUntil(
-        clients.openWindow(pusher.customerPayload.notification.deep_link)
-      );
+    const deepLink = pusher.customerPayload.notification.deep_link;
+    if (deepLink) {
+      // if the deep link is already opened, focus the existing window, else open a new window
+      const promise = clients
+        .matchAll({ includeUncontrolled: true })
+        .then(windowClients => {
+          const existingWindow = windowClients.find(
+            windowClient => windowClient.url === deepLink
+          );
+          if (existingWindow) {
+            return existingWindow.focus();
+          } else {
+            return clients.openWindow(deepLink);
+          }
+        });
+      e.waitUntil(promise);
     }
     e.notification.close();
   }

--- a/src/service-worker.test.js
+++ b/src/service-worker.test.js
@@ -28,7 +28,7 @@ beforeEach(() => {
   };
   global.clients = {
     openWindow: url => {
-      const client = { url };
+      const client = new FakeWindowClient({ url });
       clients.push(client);
       return Promise.resolve(client);
     },
@@ -313,13 +313,7 @@ test('SW should focus existing window if the deep link in click handler is alrea
   });
 
   // And an existing window of the deep link is already opened
-  clients.push({
-    url: 'https://pusher.com',
-    focus() {
-      this.focused = true;
-      return Promise.resolve(this);
-    },
-  });
+  clients.push(new FakeWindowClient({ url: 'https://pusher.com' }));
 
   // When the notificationclick listener is called
   const clickListener = listeners['notificationclick'];
@@ -734,7 +728,21 @@ const makeClickEvent = ({ data }) => {
   };
 };
 
-const registerVisibleClient = () =>
-  clients.push({ visibilityState: 'visible' });
+class FakeWindowClient {
+  constructor({ url, focused, visibilityState }) {
+    this.url = url;
+    this.focused = focused;
+    this.visibilityState = visibilityState;
+  }
 
-const registerFocusedClient = () => clients.push({ focused: true });
+  focus() {
+    this.focused = true;
+    return Promise.resolve(this);
+  }
+}
+
+const registerVisibleClient = () =>
+  clients.push(new FakeWindowClient({ visibilityState: 'visible' }));
+
+const registerFocusedClient = () =>
+  clients.push(new FakeWindowClient({ focused: true }));


### PR DESCRIPTION
Closes #94

If the deep link is already open, focus on the existing window instead of opening a new window