### PR TITLE
Add state to service worker onNotificationReceived

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -37,7 +37,7 @@ self.PusherPushNotifications = {
       client => client !== undefined
     ),
 
-  reportEvent: async ({ eventType, pusherMetadata }) => {
+  _getState: async pusherMetadata => {
     const {
       instanceId,
       publishId,
@@ -57,22 +57,34 @@ self.PusherPushNotifications = {
 
     const appInBackground = !(await self.PusherPushNotifications._hasVisibleClient());
 
+    return {
+      instanceId,
+      publishId,
+      deviceId,
+      userId,
+      appInBackground,
+      hasDisplayableContent,
+      hasData,
+    };
+  },
+
+  reportEvent: async ({ eventType, state }) => {
     const path = `${self.PusherPushNotifications._endpoint(
-      instanceId
-    )}/reporting_api/v2/instances/${instanceId}/events`;
+      state.instanceId
+    )}/reporting_api/v2/instances/${state.instanceId}/events`;
 
     const options = {
       method: 'POST',
       path,
       body: {
-        publishId,
+        publishId: state.publishId,
         event: eventType,
-        deviceId,
-        userId,
+        deviceId: state.deviceId,
+        userId: state.userId,
         timestampSecs: Math.floor(Date.now() / 1000),
-        appInBackground,
-        hasDisplayableContent,
-        hasData,
+        appInBackground: state.appInBackground,
+        hasDisplayableContent: state.hasDisplayableContent,
+        hasData: state.hasData,
       },
     };
 
@@ -96,10 +108,16 @@ self.addEventListener('push', e => {
     return; // Not a pusher notification
   }
 
-  // Report analytics event, best effort
-  self.PusherPushNotifications.reportEvent({
-    eventType: 'delivery',
-    pusherMetadata: payload.data.pusher,
+  const statePromise = self.PusherPushNotifications._getState(
+    payload.data.pusher
+  );
+
+  statePromise.then(state => {
+    // Report analytics event, best effort
+    self.PusherPushNotifications.reportEvent({
+      eventType: 'delivery',
+      state,
+    });
   });
 
   const customerPayload = { ...payload };
@@ -147,6 +165,7 @@ self.addEventListener('push', e => {
       payload: customerPayload,
       pushEvent: e,
       handleNotification,
+      statePromise,
     });
   } else {
     e.waitUntil(handleNotification(customerPayload));
@@ -158,10 +177,16 @@ self.addEventListener('notificationclick', e => {
 
   const isPusherNotification = pusher !== undefined;
   if (isPusherNotification) {
+    const statePromise = self.PusherPushNotifications._getState(
+      pusher.pusherMetadata
+    );
+
     // Report analytics event, best effort
-    self.PusherPushNotifications.reportEvent({
-      eventType: 'open',
-      pusherMetadata: pusher.pusherMetadata,
+    statePromise.then(state => {
+      self.PusherPushNotifications.reportEvent({
+        eventType: 'open',
+        state,
+      });
     });
 
     if (pusher.customerPayload.notification.deep_link) {

--- a/src/service-worker.test.js
+++ b/src/service-worker.test.js
@@ -7,6 +7,8 @@ const TEST_PUBLISH_ID = 'some-publish-id';
 const TEST_NOTIFICATION_TITLE = 'Hi!';
 const TEST_NOTIFICATION_BODY = 'This is a test notification!';
 const TEST_NOTIFICATION_ICON = 'an-icon.png';
+const TEST_DEVICE_ID = 'web-1db66b8a-f51f-49de-b225-72591535c855';
+const TEST_USER_ID = 'alice';
 
 let listeners = {};
 let shownNotifications = [];
@@ -39,9 +41,9 @@ beforeEach(() => {
   // Mock out IO modules
   const devicestatestore = require('./device-state-store');
   devicestatestore.default = makeDeviceStateStore({
-    deviceId: 'web-1db66b8a-f51f-49de-b225-72591535c855',
+    deviceId: TEST_DEVICE_ID,
     token: 'some-token',
-    userId: 'alice',
+    userId: TEST_USER_ID,
   });
   const dorequest = require('./do-request');
   dorequest.default = () => Promise.resolve('ok');
@@ -186,6 +188,17 @@ test('SW should pass correct params to onNotificationReceived', () => {
   expect(typeof onNotificationReceivedParams.handleNotification).toEqual(
     'function'
   );
+  onNotificationReceivedParams.statePromise.then(state => {
+    expect(state).toEqual({
+      instanceId: TEST_INSTANCE_ID,
+      publishId: TEST_PUBLISH_ID,
+      deviceId: TEST_DEVICE_ID,
+      userId: TEST_USER_ID,
+      appInBackground: true,
+      hasDisplayableContent: true,
+      hasData: false,
+    });
+  });
 });
 
 test('SW should show correct notification if handleNotification is called', () => {


### PR DESCRIPTION
Closes #64 

Adds the following state to the service worker [onNotificationReceived](https://pusher.com/docs/beams/guides/handle-incoming-notifications/web/) handler:
- `instanceId`
- `publishId`
- `deviceId`
- `userId`
- `appInBackground`
- `hasDisplayableContent`
- `hasData`

`deviceId` and `userId` are stored in IndexedDB. To avoid slowing down the notification if the state is not used, a `Promise` is passed to `onNotificationReceived`. For example:
```js
PusherPushNotifications.onNotificationReceived = async ({ pushEvent, payload, statePromise }) => {
  const { userId } = await statePromise;
  pushEvent.waitUntil(
    // custom notification handling logic
  );
};
```

Because these data are used by the event reporting, I've refactored `PusherPushNotifications.reportEvent` to reuse the same `Promise`, to avoid querying IndexedDB twice.