### PR TITLE
fixes #115

### DIFF
--- a/src/do-request.js
+++ b/src/do-request.js
@@ -15,7 +15,7 @@ export default function doRequest({
   if (!(function (x) { for (let i in x) return false; return true })(params)) { // check for empty params obj
     path += Object.entries(params)
               .filter(x => x[1])
-              .reduce((prev, cur) => prev + cur.map(x => encodeURIComponent(x))
+              .reduce((prev, cur) => prev + (prev !== "?" ? "&" : "") + cur.map(x => encodeURIComponent(x))
                 .join("="), "?");
   }
 

--- a/src/do-request.js
+++ b/src/do-request.js
@@ -12,22 +12,13 @@ export default function doRequest({
     credentials,
   };
 
-  if (
-    !(function(x) {
-      for (let i in x) return false;
-      return true;
-    })(params)
-  ) {
+  if (!emptyParams(params)) {
     // check for empty params obj
+    path += '?';
     path += Object.entries(params)
       .filter(x => x[1])
-      .reduce(
-        (prev, cur) =>
-          prev +
-          (prev !== '?' ? '&' : '') +
-          cur.map(x => encodeURIComponent(x)).join('='),
-        '?'
-      );
+      .map(pair => pair.map(x => encodeURIComponent(x)).join('='))
+      .join('&');
   }
 
   if (body !== null) {
@@ -46,6 +37,11 @@ export default function doRequest({
       return null;
     }
   });
+}
+
+function emptyParams(params) {
+  for (let i in params) return false;
+  return true;
 }
 
 async function handleError(response) {

--- a/src/do-request.js
+++ b/src/do-request.js
@@ -12,11 +12,22 @@ export default function doRequest({
     credentials,
   };
 
-  if (!(function (x) { for (let i in x) return false; return true })(params)) { // check for empty params obj
+  if (
+    !(function(x) {
+      for (let i in x) return false;
+      return true;
+    })(params)
+  ) {
+    // check for empty params obj
     path += Object.entries(params)
-              .filter(x => x[1])
-              .reduce((prev, cur) => prev + (prev !== "?" ? "&" : "") + cur.map(x => encodeURIComponent(x))
-                .join("="), "?");
+      .filter(x => x[1])
+      .reduce(
+        (prev, cur) =>
+          prev +
+          (prev !== '?' ? '&' : '') +
+          cur.map(x => encodeURIComponent(x)).join('='),
+        '?'
+      );
   }
 
   if (body !== null) {

--- a/src/do-request.js
+++ b/src/do-request.js
@@ -1,6 +1,7 @@
 export default function doRequest({
   method,
   path,
+  params = {},
   body = null,
   headers = {},
   credentials = 'same-origin',
@@ -10,6 +11,13 @@ export default function doRequest({
     headers,
     credentials,
   };
+
+  if (!(function (x) { for (let i in x) return false; return true })(params)) { // check for empty params obj
+    path += Object.entries(params)
+              .filter(x => x[1])
+              .reduce((prev, cur) => prev + cur.map(x => encodeURIComponent(x))
+                .join("="), "?");
+  }
 
   if (body !== null) {
     options.body = JSON.stringify(body);

--- a/src/do-request.test.js
+++ b/src/do-request.test.js
@@ -17,6 +17,19 @@ test('Handles URL with params', () => {
   );
 });
 
+test('Handles URL with multiple params', () => {
+  const options = {
+    method: 'GET',
+    path: 'http://fake-url.com',
+    params: { search: 'test string', other: 123 },
+  };
+  return doRequest(options).then(() =>
+    expect(fetch.mock.calls[1][0]).toEqual(
+      'http://fake-url.com?search=test%20string&other=123'
+    )
+  );
+});
+
 test('Handles responses with no body', () => {
   const options = { method: 'POST', path: 'http://fake-url.com' };
   return doRequest(options).then(res => expect(res).toBeNull());

--- a/src/do-request.test.js
+++ b/src/do-request.test.js
@@ -4,6 +4,11 @@ test('doRequest', () => {
   expect(typeof doRequest).toBe('function');
 });
 
+test('Handles URL with params', () => {
+  const options = { method: 'GET', path: 'http://fake-url.com', params: { search: "test string" } };
+  return doRequest(options).then(() => expect(fetch.mock.lastCall[0]).toEqual("http://fake-url.com?search=test%20string"));
+});
+
 test('Handles responses with no body', () => {
   const options = { method: 'POST', path: 'http://fake-url.com' };
   return doRequest(options).then(res => expect(res).toBeNull());

--- a/src/do-request.test.js
+++ b/src/do-request.test.js
@@ -6,7 +6,7 @@ test('doRequest', () => {
 
 test('Handles URL with params', () => {
   const options = { method: 'GET', path: 'http://fake-url.com', params: { search: "test string" } };
-  return doRequest(options).then(() => expect(fetch.mock.lastCall[0]).toEqual("http://fake-url.com?search=test%20string"));
+  return doRequest(options).then(() => expect(fetch.mock.calls[0][0]).toEqual("http://fake-url.com?search=test%20string"));
 });
 
 test('Handles responses with no body', () => {

--- a/src/do-request.test.js
+++ b/src/do-request.test.js
@@ -5,8 +5,16 @@ test('doRequest', () => {
 });
 
 test('Handles URL with params', () => {
-  const options = { method: 'GET', path: 'http://fake-url.com', params: { search: "test string" } };
-  return doRequest(options).then(() => expect(fetch.mock.calls[0][0]).toEqual("http://fake-url.com?search=test%20string"));
+  const options = {
+    method: 'GET',
+    path: 'http://fake-url.com',
+    params: { search: 'test string' },
+  };
+  return doRequest(options).then(() =>
+    expect(fetch.mock.calls[0][0]).toEqual(
+      'http://fake-url.com?search=test%20string'
+    )
+  );
 });
 
 test('Handles responses with no body', () => {

--- a/src/push-notifications.js
+++ b/src/push-notifications.js
@@ -258,8 +258,8 @@ export class Client {
     };
     let res = await doRequest(options);
     res = {
-      interests: res['interests'] || [],
-      ...(res?.responseMetadata || {})
+      interests: (res && res['interests']) || [],
+      ...((res && res.responseMetadata) || {})
     };
     return res;
   }

--- a/src/push-notifications.js
+++ b/src/push-notifications.js
@@ -244,7 +244,7 @@ export class Client {
     await doRequest(options);
   }
 
-  async getDeviceInterests() {
+  async getDeviceInterests(limit = 100, cursor = null) {
     await this._resolveSDKState();
     this._throwIfNotStarted('Could not get Device Interests');
 
@@ -254,8 +254,14 @@ export class Client {
     const options = {
       method: 'GET',
       path,
+      params: { limit, cursor }
     };
-    return (await doRequest(options))['interests'] || [];
+    let res = await doRequest(options);
+    res = {
+      interests: res['interests'] || [],
+      ...(res?.responseMetadata || {})
+    };
+    return res;
   }
 
   async setDeviceInterests(interests) {
@@ -352,7 +358,7 @@ export class Client {
 
     await this._deleteDevice();
     await this._deviceStateStore.clear();
-    this._clearPushToken().catch(() => {}); // Not awaiting this, best effort.
+    this._clearPushToken().catch(() => { }); // Not awaiting this, best effort.
 
     this._deviceId = null;
     this._token = null;

--- a/src/push-notifications.js
+++ b/src/push-notifications.js
@@ -254,12 +254,12 @@ export class Client {
     const options = {
       method: 'GET',
       path,
-      params: { limit, cursor }
+      params: { limit, cursor },
     };
     let res = await doRequest(options);
     res = {
       interests: (res && res['interests']) || [],
-      ...((res && res.responseMetadata) || {})
+      ...((res && res.responseMetadata) || {}),
     };
     return res;
   }
@@ -358,7 +358,7 @@ export class Client {
 
     await this._deleteDevice();
     await this._deviceStateStore.clear();
-    this._clearPushToken().catch(() => { }); // Not awaiting this, best effort.
+    this._clearPushToken().catch(() => {}); // Not awaiting this, best effort.
 
     this._deviceId = null;
     this._token = null;

--- a/src/push-notifications.test.js
+++ b/src/push-notifications.test.js
@@ -314,6 +314,10 @@ describe('interest methods', () => {
         expect(mockDoRequest.mock.calls[0].length).toBe(1);
         expect(mockDoRequest.mock.calls[0][0]).toEqual({
           method: 'GET',
+          params: {
+            cursor: null,
+            limit: 100,
+          },
           path: [
             'https://df3c1965-e870-4bd6-8d75-fea56b26335f.pushnotifications.pusher.com',
             '/device_api/v1/instances/df3c1965-e870-4bd6-8d75-fea56b26335f',
@@ -321,7 +325,9 @@ describe('interest methods', () => {
             '/interests',
           ].join(''),
         });
-        expect(interests).toEqual(['donuts']);
+        expect(interests).toEqual({
+          interests: ['donuts'],
+        });
       });
     });
 

--- a/src/push-notifications.test.js
+++ b/src/push-notifications.test.js
@@ -346,7 +346,7 @@ describe('interest methods', () => {
       const beamsClient = new PusherPushNotifications.Client({
         instanceId,
       });
-        return beamsClient.getDeviceInterests(150, 2).then(interests => {
+      return beamsClient.getDeviceInterests(150, 2).then(interests => {
         expect(mockDoRequest.mock.calls.length).toBe(1);
         expect(mockDoRequest.mock.calls[0].length).toBe(1);
         expect(mockDoRequest.mock.calls[0][0]).toEqual({
@@ -366,8 +366,7 @@ describe('interest methods', () => {
           interests: ['donuts'],
         });
       });
-    }
-        );
+    });
 
     test('should fail if SDK is not started', () => {
       // Emulate a fresh SDK, where start has not been called

--- a/src/push-notifications.test.js
+++ b/src/push-notifications.test.js
@@ -330,6 +330,44 @@ describe('interest methods', () => {
         });
       });
     });
+    test('should make correct request with cursor and return the interests', () => {
+      const instanceId = 'df3c1965-e870-4bd6-8d75-fea56b26335f';
+
+      const mockDoRequest = jest.fn();
+      mockDoRequest.mockReturnValueOnce(
+        Promise.resolve({
+          interests: ['donuts'],
+          responseMetadata: {},
+        })
+      );
+
+      dorequest.default = mockDoRequest;
+
+      const beamsClient = new PusherPushNotifications.Client({
+        instanceId,
+      });
+        return beamsClient.getDeviceInterests(150, 2).then(interests => {
+        expect(mockDoRequest.mock.calls.length).toBe(1);
+        expect(mockDoRequest.mock.calls[0].length).toBe(1);
+        expect(mockDoRequest.mock.calls[0][0]).toEqual({
+          method: 'GET',
+          params: {
+            cursor: 2,
+            limit: 150,
+          },
+          path: [
+            'https://df3c1965-e870-4bd6-8d75-fea56b26335f.pushnotifications.pusher.com',
+            '/device_api/v1/instances/df3c1965-e870-4bd6-8d75-fea56b26335f',
+            '/devices/web/web-1db66b8a-f51f-49de-b225-72591535c855',
+            '/interests',
+          ].join(''),
+        });
+        expect(interests).toEqual({
+          interests: ['donuts'],
+        });
+      });
+    }
+        );
 
     test('should fail if SDK is not started', () => {
       // Emulate a fresh SDK, where start has not been called


### PR DESCRIPTION
## Description

As per [docs](https://pusher.com/docs/beams/reference/device-api/#get-device-interests), `getDeviceInterests` must accept `limit` and `cursor` args to be passed with query parameters in the API. Currently, API returns 100 results since limit implies with 100 as default value in API, so i first redesigned the endpoint caller function [here](https://github.com/Harsh-br0/push-notifications-web/commit/3814043bef3f4d59551e6b00c1b8cb638bb85ae7#diff-c405300bdd7392f9cff32defeed065d087aa459b777bc92a572d15b0f5b9d818) to accept query params as object in `params` arg and reworked the `getDeviceInterests` method [here](https://github.com/Harsh-br0/push-notifications-web/commit/3814043bef3f4d59551e6b00c1b8cb638bb85ae7#diff-7bf72bd6d34d65d4e52988363eb87d79b078c4f012dabcf8b17cbf308fa19262) to return value as Object that includes `cursor` field from API response and add `limit` and `cursor` to method parameters.
Also I've added a test for `params` arg in [do-request.test.js](https://github.com/Harsh-br0/push-notifications-web/commit/3814043bef3f4d59551e6b00c1b8cb638bb85ae7#diff-dc6067f72e25ab188e763be833c0002c273e07ba4cb31999e2c80ebc02549017)

### Notable Changes

- `getDeviceInterests` now returns Object instead of an Array.
- Internal `doRequest` function can have params arg in Object to represent query params in URL



<br><br>



_potentially fixes #115_ 