### PR TITLE
chore: add type: module to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.0",
   "description": "",
   "main": "dist/push-notifications-esm.js",
+  "type": "module",
   "types": "index.d.ts",
   "scripts": {
     "build:esm": "rollup -c ./rollup/esm.js",


### PR DESCRIPTION
This change will make sure that this package can be used as a collection of ESM modules. It fixes #78.